### PR TITLE
Add mcp-get installation instructions and restore uvx configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ An MCP server to interact with a Tinybird Workspace from any MCP client.
 
 ## Setup
 
+### Installation
+
+You can install the Tinybird MCP server using mcp-get:
+
+```bash
+npx @michaellatman/mcp-get@latest install mcp-tinybird
+```
+
 ### Prerequisites
 
 MCP is still very new and evolving, we recommend following the [MCP documentation](https://modelcontextprotocol.io/quickstart#prerequisites) to get the MCP basics up and running.
@@ -22,13 +30,12 @@ MCP is still very new and evolving, we recommend following the [MCP documentatio
 You'll need:
 - [Tinybird Account & Workspace](https://www.tinybird.co/)
 - [Claude Desktop](https://claude.ai/)
-- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ### Configuration
 
 #### 1. Configure Claude Desktop
 
-Create the following file depending on your OS
+Create the following file depending on your OS:
 
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
@@ -40,10 +47,7 @@ Paste this template in the file and replace `<TINYBIRD_API_URL>` and `<TINYBIRD_
 {
     "mcpServers": {
         "mcp-tinybird": {
-            "command": "uvx",
-            "args": [
-                "mcp-tinybird"
-            ],
+            "command": "mcp-tinybird",
             "env": {
                 "TB_API_URL": "<TINYBIRD_API_URL>",
                 "TB_ADMIN_TOKEN": "<TINYBIRD_ADMIN_TOKEN>"
@@ -91,7 +95,7 @@ The server implements several tools to interact with the Tinybird Workspace:
 
 ## Development
 
-### Config 
+### Config
 If you are working locally add two environment variables to a `.env` file in the root of the repository:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ MCP is still very new and evolving, we recommend following the [MCP documentatio
 You'll need:
 - [Tinybird Account & Workspace](https://www.tinybird.co/)
 - [Claude Desktop](https://claude.ai/)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ### Configuration
 
@@ -47,7 +48,10 @@ Paste this template in the file and replace `<TINYBIRD_API_URL>` and `<TINYBIRD_
 {
     "mcpServers": {
         "mcp-tinybird": {
-            "command": "mcp-tinybird",
+            "command": "uvx",
+            "args": [
+                "mcp-tinybird"
+            ],
             "env": {
                 "TB_API_URL": "<TINYBIRD_API_URL>",
                 "TB_ADMIN_TOKEN": "<TINYBIRD_ADMIN_TOKEN>"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ TB_API_URL=
 TB_ADMIN_TOKEN=
 ```
 
+For local development, update your Claude Desktop configuration:
+
 ```json
 {
   "mcpServers": {
@@ -114,7 +116,7 @@ TB_ADMIN_TOKEN=
       "command": "uv",
       "args": [
         "--directory",
-        "/Users/alrocar/gr/mcp-tinybird",
+        "/path/to/your/mcp-tinybird",
         "run",
         "mcp-tinybird"
       ]
@@ -122,6 +124,21 @@ TB_ADMIN_TOKEN=
   }
 }
 ```
+
+<details>
+  <summary>Published Servers Configuration</summary>
+
+  ```json
+  "mcpServers": {
+    "mcp-tinybird": {
+      "command": "uvx",
+      "args": [
+        "mcp-tinybird"
+      ]
+    }
+  }
+  ```
+</details>
 
 ### Building and Publishing
 


### PR DESCRIPTION
This PR adds mcp-get installation instructions while preserving all uvx-related configurations:

- Added mcp-get installation section
- Restored uvx prerequisites
- Maintained uvx command and args in main configuration
- Restored development configuration with uv command
- Added back published servers configuration with uvx

These changes ensure both installation methods (mcp-get and uvx) are properly documented.